### PR TITLE
Really fix page-load-start not being emitted

### DIFF
--- a/.changeset/tidy-doors-build.md
+++ b/.changeset/tidy-doors-build.md
@@ -1,0 +1,5 @@
+---
+'page-lifecycle-provider': patch
+---
+
+Fix page-load-started not firing when page completes quickly (actually fixing it this time)


### PR DESCRIPTION
This basically undoes the previous commit (which was deferring the page-load-complete) and instead just generates the page-load-start earlier